### PR TITLE
presence_dialoginfo: Fix memory leaks in notify_body.c

### DIFF
--- a/modules/presence_dialoginfo/notify_body.c
+++ b/modules/presence_dialoginfo/notify_body.c
@@ -415,13 +415,14 @@ str* build_dialoginfo(str* pres_user, str* pres_domain)
 	if(body == NULL)
 	{
 		LM_ERR("while allocating memory\n");
-		return NULL;
+		goto error;
 	}
 	memset(body, 0, sizeof(str));
 
 	xmlDocDumpMemory(doc,(unsigned char**)(void*)&body->s,&body->len);
 
 	LM_DBG("new_body:\n%.*s\n",body->len, body->s);
+	pkg_free(pres_uri);
 	/*free the document */
 	xmlFreeDoc(doc);
 	xmlCleanupParser();


### PR DESCRIPTION
Found this while working on a related project.
